### PR TITLE
config: Add redirect /ru/rules -> /rules

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -35,7 +35,20 @@ const config = {
       },
     },
   },
-  plugins: ['docusaurus-plugin-sass'],
+  plugins: ['docusaurus-plugin-sass',
+    ["@docusaurus/plugin-client-redirects",
+      {
+        redirects: [
+          // Since 'ru' is default locale, '/ru' path is omitted. We need redirect for some pages where url
+          // may differ based on user locale in the app.
+          {
+            to: '/rules',
+            from: '/ru/rules',
+          },
+        ],
+      }
+    ],
+  ],
   presets: [
     [
       'classic',

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.1.0",
+    "@docusaurus/plugin-client-redirects": "^2.1.0",
     "@docusaurus/plugin-google-gtag": "^2.1.0",
     "@docusaurus/preset-classic": "2.1.0",
     "@mdx-js/react": "^1.6.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1330,6 +1330,21 @@
     react-helmet-async "*"
     react-loadable "npm:@docusaurus/react-loadable@5.5.2"
 
+"@docusaurus/plugin-client-redirects@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.1.0.tgz#4141040552faad48aefc5bc8f3827c3c4eba1ab8"
+  integrity sha512-3PhzwHSyZWqBAFPJuLJE3dZVuKWQEj9ReQP85Z3/2hpnQoVNBgAqc+64FIko0FvvK1iluLeasO7NWGyuATngvw==
+  dependencies:
+    "@docusaurus/core" "2.1.0"
+    "@docusaurus/logger" "2.1.0"
+    "@docusaurus/utils" "2.1.0"
+    "@docusaurus/utils-common" "2.1.0"
+    "@docusaurus/utils-validation" "2.1.0"
+    eta "^1.12.3"
+    fs-extra "^10.1.0"
+    lodash "^4.17.21"
+    tslib "^2.4.0"
+
 "@docusaurus/plugin-content-blog@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz#32b1a7cd4b0026f4a76fce4edc5cfdd0edb1ec42"


### PR DESCRIPTION
Since `ru` is default locale in docs, `/ru` path is omitted. We need redirect for some pages where url may differ based on user locale in the app.