### PR TITLE
Add redirect /ru/about -> /about

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -45,6 +45,10 @@ const config = {
             to: '/rules',
             from: '/ru/rules',
           },
+          {
+            to: '/about',
+            from: '/ru/about',
+          },
         ],
       }
     ],


### PR DESCRIPTION
Since `ru` is default locale in docs, `/ru` path is omitted. We need redirect for some pages where url may differ based on user locale in the app.