### PR TITLE
en: Add statistics page.

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -3,7 +3,7 @@ title: Contributing
 tags:
   - contributing
   - getting started
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Contributing

--- a/docs/dev/_category_.json
+++ b/docs/dev/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Development",
-  "position": 2,
+  "position": 3,
   "link": {
     "type": "generated-index",
     "title": "Developer Resources",

--- a/docs/stat.md
+++ b/docs/stat.md
@@ -1,0 +1,36 @@
+---
+id: stats
+slug: /stats
+sidebar_position: 2
+---
+
+import {DataWrapperChart} from '@site/src/components/DataWrapper';
+
+# Statistics
+
+You can explore annual statics in the charts below. The current statistical information can be viewed within PastVu webapp by selecting "Statistics" at the navigation bar below "News" area.
+
+## Uploads
+
+<DataWrapperChart title="Photos Uploads" chartId="VlujH" />
+
+<DataWrapperChart title="Paintings Uploads" chartId="IFA49" />
+
+<DataWrapperChart title="Total Uploads" chartId="j7vds" />
+
+## Comments
+
+<DataWrapperChart title="News Comments" chartId="1Zy0k" />
+
+<DataWrapperChart title="Images Comments" chartId="xUpS6" />
+
+<DataWrapperChart title="Total Comments" chartId="tzXIK" />
+
+## Users
+
+<DataWrapperChart title="New Users" chartId="7CQIV" />
+
+<DataWrapperChart title="Users Activity" chartId="yK3ON" />
+
+<DataWrapperChart title="Total Users" chartId="XUhbS" />
+

--- a/src/components/DataWrapper/index.tsx
+++ b/src/components/DataWrapper/index.tsx
@@ -1,0 +1,48 @@
+import React, {type ReactNode} from 'react';
+import styles from './styles.module.css';
+import {useColorMode} from '@docusaurus/theme-common';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+type DataWrapperChartProps = {
+  title: string;
+  chartId: string;
+}
+
+if (ExecutionEnvironment.canUseEventListeners) {
+    // iframe resize snippet https://developer.datawrapper.de/docs/responsive-iframe#constructing-a-responsive-embed-code
+    window.addEventListener('message', function(event) {
+        if (typeof event.data['datawrapper-height'] !== 'undefined') {
+            var iframes = document.querySelectorAll('iframe');
+            for (var chartId in event.data['datawrapper-height']) {
+                for (var i = 0; i < iframes.length; i++) {
+                    if (iframes[i].contentWindow === event.source) {
+                        var iframe = iframes[i]
+                        iframe.style.height = event.data['datawrapper-height'][chartId] + 'px';
+                    }
+                }
+            }
+        }
+    });
+}
+
+
+const MyComponent = () => {
+  return (
+    <BrowserOnly>
+      {() => <span>page url = {window.location.href}</span>}
+    </BrowserOnly>
+  );
+};
+
+export function DataWrapperChart ({
+    title,
+    chartId
+}: DataWrapperChartProps): JSX.Element {
+    const {colorMode} = useColorMode();
+    const darkSuffix = colorMode === 'dark' ? '?dark=true' : '';
+    return (
+        <p className={styles.DataWrapperChart}>
+            <iframe title={title} aria-label={`${title} chart`} id={`datawrapper-chart-${chartId}`} src={`https://datawrapper.dwcdn.net/${chartId}/${darkSuffix}`} scrolling="no" frameBorder="0" width="600" height="420" data-external="1"></iframe>
+        </p>
+    )
+}

--- a/src/components/DataWrapper/styles.module.css
+++ b/src/components/DataWrapper/styles.module.css
@@ -1,0 +1,3 @@
+.DataWrapperChart {
+    padding-left: 2px;
+}


### PR DESCRIPTION
This is annual statistics page with charts generated using Datawrapper service. It is using Google sheets as data backend, but this needs to be converted to CSV in this repo and linked to charts.

Charts are located at: https://app.datawrapper.de/archive/team/df5RIUxk/137902